### PR TITLE
Style docstrings as comments in all solarized theme variants

### DIFF
--- a/themes/braver-solarized-dark-color-theme.json
+++ b/themes/braver-solarized-dark-color-theme.json
@@ -29,6 +29,7 @@
       "name": "Comment",
       "scope": [
         "comment",
+        "string.quoted.docstring",
         "meta.documentation"
       ],
       "settings": {

--- a/themes/braver-solarized-dark-with-workbench-color-theme.json
+++ b/themes/braver-solarized-dark-with-workbench-color-theme.json
@@ -5,6 +5,7 @@
       "name": "Comment",
       "scope": [
         "comment",
+        "string.quoted.docstring",
         "meta.documentation"
       ],
       "settings": {

--- a/themes/braver-solarized-light-color-theme.json
+++ b/themes/braver-solarized-light-color-theme.json
@@ -32,6 +32,7 @@
       "name": "Comment",
       "scope": [
         "comment",
+        "string.quoted.docstring",
         "meta.documentation"
       ],
       "settings": {

--- a/themes/braver-solarized-light-with-workbench-color-theme.json
+++ b/themes/braver-solarized-light-with-workbench-color-theme.json
@@ -6,6 +6,7 @@
       "name": "Comment",
       "scope": [
         "comment",
+        "string.quoted.docstring",
         "meta.documentation"
       ],
       "settings": {


### PR DESCRIPTION
Added 'string.quoted.docstring' to the comment scope selectors in the dark, light, and workbench variants so that docstrings receive the same color treatment as comments.


Example:

<img width="600" height="168" alt="image" src="https://github.com/user-attachments/assets/4a9cd80a-1aa7-4d27-b136-044929f53f1a" />

The docstring in python does not show up as bright string-color, but instead as comment color.
